### PR TITLE
Add displayNames

### DIFF
--- a/src/Margin.jsx
+++ b/src/Margin.jsx
@@ -54,3 +54,5 @@ export const Margin = styled.div`
   ${({ bottom, theme }) => _mb(bottom, theme)} 
   ${({ left, theme }) => _ml(left, theme)} 
 `;
+
+Margin.displayName = 'Margin';

--- a/src/Padding.jsx
+++ b/src/Padding.jsx
@@ -55,4 +55,6 @@ export const Padding = styled.div`
   ${({ left, theme }) => _pl(left, theme)} 
 `;
 
+Padding.displayName = 'Padding';
+
 export default Padding;


### PR DESCRIPTION
Some source code rendering libraries rely on react components having a displayName set.

Currently outputs `<Styled(Component) top={3}>` instead of `<Margin top={3}>`