### PR TITLE
Fix zero indexed margin/paddings issue.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -40,7 +40,7 @@ export function getSpacingFromTheme(key: string, theme: Theme): string {
 
 export function _m(values: Values, theme: Theme) {
   return map(values, key => {
-    if (key) {
+    if (typeof key !== 'undefined') {
       return `
         margin: ${getSpacingFromTheme(key, theme)};
       `;
@@ -52,7 +52,7 @@ export function _m(values: Values, theme: Theme) {
 
 export function _mx(values: Values, theme: Theme) {
   return map(values, key => {
-    if (key) {
+    if (typeof key !== 'undefined') {
       return `
         margin-left: ${getSpacingFromTheme(key, theme)};
         margin-right: ${getSpacingFromTheme(key, theme)};
@@ -65,7 +65,7 @@ export function _mx(values: Values, theme: Theme) {
 
 export function _my(values: Values, theme: Theme) {
   return map(values, key => {
-    if (key) {
+    if (typeof key !== 'undefined') {
       return `
         margin-top: ${getSpacingFromTheme(key, theme)};
         margin-bottom: ${getSpacingFromTheme(key, theme)};
@@ -78,7 +78,7 @@ export function _my(values: Values, theme: Theme) {
 
 export function _mt(values: Values, theme: Theme) {
   return map(values, key => {
-    if (key) {
+    if (typeof key !== 'undefined') {
       return `
         margin-top: ${getSpacingFromTheme(key, theme)};
       `;
@@ -90,7 +90,7 @@ export function _mt(values: Values, theme: Theme) {
 
 export function _mr(values: Values, theme: Theme) {
   return map(values, key => {
-    if (key) {
+    if (typeof key !== 'undefined') {
       return `
         margin-right: ${getSpacingFromTheme(key, theme)};
       `;
@@ -102,7 +102,7 @@ export function _mr(values: Values, theme: Theme) {
 
 export function _mb(values: Values, theme: Theme) {
   return map(values, key => {
-    if (key) {
+    if (typeof key !== 'undefined') {
       return `
         margin-bottom: ${getSpacingFromTheme(key, theme)};
       `;
@@ -114,7 +114,7 @@ export function _mb(values: Values, theme: Theme) {
 
 export function _ml(values: Values, theme: Theme) {
   return map(values, key => {
-    if (key) {
+    if (typeof key !== 'undefined') {
       return `
       margin-left: ${getSpacingFromTheme(key, theme)};
       `;
@@ -126,7 +126,7 @@ export function _ml(values: Values, theme: Theme) {
 
 export function _p(values: Values, theme: Theme) {
   return map(values, key => {
-    if (key) {
+    if (typeof key !== 'undefined') {
       return `
         padding: ${getSpacingFromTheme(key, theme)};
       `;
@@ -138,7 +138,7 @@ export function _p(values: Values, theme: Theme) {
 
 export function _px(values: Values, theme: Theme) {
   return map(values, key => {
-    if (key) {
+    if (typeof key !== 'undefined') {
       return `
         padding-left: ${getSpacingFromTheme(key, theme)};
         padding-right: ${getSpacingFromTheme(key, theme)};
@@ -151,7 +151,7 @@ export function _px(values: Values, theme: Theme) {
 
 export function _py(values: Values, theme: Theme) {
   return map(values, key => {
-    if (key) {
+    if (typeof key !== 'undefined') {
       return `
         padding-top: ${getSpacingFromTheme(key, theme)};
         padding-bottom: ${getSpacingFromTheme(key, theme)};
@@ -164,7 +164,7 @@ export function _py(values: Values, theme: Theme) {
 
 export function _pt(values: Values, theme: Theme) {
   return map(values, key => {
-    if (key) {
+    if (typeof key !== 'undefined') {
       return `
         padding-top: ${getSpacingFromTheme(key, theme)};
       `;
@@ -176,7 +176,7 @@ export function _pt(values: Values, theme: Theme) {
 
 export function _pr(values: Values, theme: Theme) {
   return map(values, key => {
-    if (key) {
+    if (typeof key !== 'undefined') {
       return `
         padding-right: ${getSpacingFromTheme(key, theme)};
       `;
@@ -188,7 +188,7 @@ export function _pr(values: Values, theme: Theme) {
 
 export function _pb(values: Values, theme: Theme) {
   return map(values, key => {
-    if (key) {
+    if (typeof key !== 'undefined') {
       return `
         padding-bottom: ${getSpacingFromTheme(key, theme)};
       `;
@@ -200,7 +200,7 @@ export function _pb(values: Values, theme: Theme) {
 
 export function _pl(values: Values, theme: Theme) {
   return map(values, key => {
-    if (key) {
+    if (typeof key !== 'undefined') {
       return `
         padding-left: ${getSpacingFromTheme(key, theme)};
       `;


### PR DESCRIPTION
# Description
This PR fixes the bug when zero indexed values are simply ignored and not outputted. To reproduce the bug - define spacings object with a zero indexed value(my specific case as an example):
```js
  spacing: {
    0: '0',
    1: '0.8rem',
    2: '1.6rem',
    3: '2.4rem',
    4: '3.2rem',
    5: '4rem',
    8: '6.4rem',
    10: '8rem',
    15: '12rem'
  },
```
And then just define a padding or margin component using a zero margin(again my case for example):
```jsx
<Padding vertical={{ xsmall: 3, small: 0 }}>
    <SomeComponent/>
</Padding>
```
Expected result would be a zero padding wrapped in `small` media rule overriding `2.4rem` padding.
Actual result - an empty class name.
After some debugging I stumbled upon this code which is used across all padding and margin functions and checks the key's value.
```js
    if (key) {
      return `
        padding-top: ${getSpacingFromTheme(key, theme)};
        padding-bottom: ${getSpacingFromTheme(key, theme)};
      `;
    } else {
      return '';
    }
```
Obviously all 0 keys will be treated as false and return an empty string.